### PR TITLE
Modman fixes

### DIFF
--- a/modman
+++ b/modman
@@ -1,3 +1,4 @@
 #b-responsive theme
-skin/frontend/enterprise/responsive 			skin/frontend/enterprise/responsive
-app/design/frontend/enterprise/responsive 		app/design/frontend/enterprise/responsive
+skin/frontend/b-responsive 			skin/frontend/b-responsive
+skin/frontend/enterprise/responsive skin/frontend/enterprise/responsive
+app/design/frontend/b-responsive    app/design/frontend/b-responsive

--- a/modman
+++ b/modman
@@ -1,4 +1,15 @@
 #b-responsive theme
-skin/frontend/b-responsive 			skin/frontend/b-responsive
-skin/frontend/enterprise/responsive skin/frontend/enterprise/responsive
-app/design/frontend/b-responsive    app/design/frontend/b-responsive
+
+# SKIN
+skin/frontend/b-responsive/default              skin/frontend/b-responsive/default
+skin/frontend/enterprise/responsive             skin/frontend/enterprise/responsive
+
+# DESIGN
+app/design/frontend/b-responsive/default        app/design/frontend/b-responsive/default
+app/design/frontend/b-responsive/enterprise     app/design/frontend/b-responsive/enterprise
+
+# MODULE
+app/code/community/RedLightBlinking/Setup       app/code/community/RedLightBlinking/Setup
+
+# MODULE ACTIVATION FILE
+app/etc/modules/RedLightBlinking_Setup.xml      app/etc/modules/RedLightBlinking_Setup.xml


### PR DESCRIPTION
Organized the modman file and splitted default and enterprise themes in order to let others to create their own theme inside b-responsive package so that modman won't delete them when deploying/upgrading.
