### PR TITLE
Makes b-responsive installable via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "redlightblinking/b-responsive",
+    "description": "Magento Responsive Theme built with Twitter Bootstrap v3",
+    "type": "magento-module",
+    "license": "GPL",
+    "authors": [
+        {
+            "name": "Red Light Blinking",
+            "email": "info@redlightblinking.com"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}


### PR DESCRIPTION
Makes b-responsive compatible with magento-hackathon/magento-composer-installer (https://github.com/magento-hackathon/magento-composer-installer)
