### PR TITLE
Modman mapping fix

### DIFF
--- a/modman
+++ b/modman
@@ -6,5 +6,4 @@ app/etc/modules/RedLightBlinking_Setup.xml                  app/etc/modules/RedL
 app/etc/modules/RedLightBlinking_MegaMenu.xml               app/etc/modules/RedLightBlinking_MegaMenu.xml
 app/etc/modules/RedLightBlinking_ProductSlider.xml          app/etc/modules/RedLightBlinking_ProductSlider.xml
 skin/frontend/b-responsive                                  skin/frontend/b-responsive
-skin/frontend/enterprise/responsive                         skin/frontend/enterprise/responsive
 skin/frontend/default/default/js/productslider              skin/frontend/default/default/js/productslider


### PR DESCRIPTION
In the modman mapping file you have the following line:

```
skin/frontend/enterprise/responsive                         skin/frontend/enterprise/responsive
```

This line causes the following error when installing with Composer and Magento Composer Installer:

```
[ErrorException]                                                                                                                         
  Source ... /vendor/redlightblinking/b-responsive/skin/frontend/enterprise/responsive does not exist
```

And it's true because there isn't any `skin/frontend/enterprise/responsive` path in your repo. So I removed that line.

Let us know. Thank you.
